### PR TITLE
Feature/integrate markdown2html

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bin/markdown2html"]
+	path = bin/markdown2html
+	url = https://github.com/phnmnl/markdown2html.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-#Federated Git Wiki
-Version 0.3
+# Federated Git Wiki
+Version 0.4.0
 
-#Installation
+
+## Installation
 Make sure Python is install in the unix based system.
 
 Install markdown 2
@@ -16,23 +17,32 @@ Initialise by running the following under your hosting folder
 
     ./bin/run.sh
 
-Setting permission of `bin` `conf` to be 644, other folders can be set as 755
-
+Setting permission of `bin` `conf` to be 644, other folders can be set as 755 
 `path` in `bin` needs to be set.
 
-## Note
 
-If crontab is used, markdown2 needs to specify location
+## Notes
 
-##Updates v0.3.1
+* This repository uses a Git submodule. To easily initialize and update 
+the submodule pass the option `--recurse-submodules` 
+to the `git clone` command.
+
+* If crontab is used, the absolute location of markdown2 needs to be specified
+
+## Changelog
+
+##### Updates v0.4.0
+Integrate `markdown2html` as a conversion tool
+
+##### Updates v0.3.1
 Improve bash
 Add full text search
 
-##Updates v0.2.2
+##### Updates v0.2.2
 Add query string to redirect pages
 
-##Updates v0.2.1
+##### Updates v0.2.1
 Production version
 
-##Updates v0.2
+##### Updates v0.2
 Data can be pulled across and displayed

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,35 +1,19 @@
 #!/usr/bin/env bash
+
+# configuration
 path="/var/www/html/php-phenomenal-portal-wiki"
-markdownFolder="$path/wiki-markdown"
 htmlFolder="$path/wiki-html"
+markdownFolder="$path/wiki-markdown"
 gitList="$path/conf/gitList.txt"
-extension=".html"
+gitBranch="master"
 
-mkdir -p $markdownFolder
-mkdir -p $htmlFolder
+# path of this script
+current_path="$( cd "$(dirname "${0}")" ; pwd -P )"
 
-cd $markdownFolder && rm -rf *
-
-echo $gitList
-
-while IFS= read line
-do
-    git clone "$line"
-done <"$gitList"
-
-# For running inside cron, for markdown2
-PATH=/usr/local/bin/:$PATH
-
-for dir in `ls ./`;
-do
-    mkdir -p "$htmlFolder/$dir"
-    for file in `ls ./$dir`;
-    do
-	    if [[ -f "$dir/$file" ]]; then
-			filename="${file%.*}"
-			markdown2 --extras fenced-code-blocks "$dir/$file" > "$htmlFolder/$dir/$filename"
-			cp "$htmlFolder/$dir/$filename" "$htmlFolder/$dir/$filename$extension"
-	    fi
-	    cp -r "$dir/$file" "$htmlFolder/$dir/$file"
-    done
-done
+# launch converter
+"${current_path}/markdown2html/run.sh" \
+    --force-cleanup \
+    --html "${htmlFolder}" \
+    --md "${markdownFolder}" \
+    --git-branch "${gitBranch}" \
+    "${gitList}"


### PR DESCRIPTION
This PR integrates the [`markdown2html` ](https://github.com/phnmnl/markdown2html) utility to convert markdown coming from git repositories to html.